### PR TITLE
Create paper-card component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
-# paper-card
-A paper card control à la Material Design
+paper-card
+==============
+
+See the [component page](http://polymerlabs.github.io/paper-card) for more information.

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,11 @@
+{
+  "name": "paper-card",
+  "private": true,
+  "dependencies": {
+    "polymer": "Polymer/polymer#master",
+    "swipeable-card": "PolymerLabs/swipeable-card#master"
+  },
+  "devDependencies": {
+    "web-component-tester": "Polymer/web-component-tester#^1.0.0"
+  }
+}

--- a/demo.html
+++ b/demo.html
@@ -1,0 +1,170 @@
+<!doctype html>
+<html>
+<head>
+  <title>paper-card</title>
+
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+
+  <script src="../webcomponentsjs/webcomponents.js"></script>
+
+  <link rel="import" href="paper-card.html">
+  <link rel="import" href="../paper-button/paper-button.html">
+  <link rel="import" href="../core-icon-button/core-icon-button.html">
+
+  <style>
+    body {
+      font-family: RobotoDraft, 'Helvetica Neue', Helvetica, Arial;
+      font-size: 14px;
+    }
+
+    #cards {
+      margin: 0 auto;
+      background: #dedede;
+      overflow: auto;
+      -webkit-user-select: none;
+      -moz-user-select: none;
+    }
+
+    paper-card {
+      width: 380px;
+      margin: 8px auto;
+    }
+
+    paper-card [autofocus] {
+      color: #ff9c33;
+    }
+
+    paper-button {
+      font-size: 14px;
+    }
+
+    .fancy .round-placeholder {
+      display: inline-block;
+      height: 64px;
+      width: 64px;
+      border-radius: 50%;
+      background: #e9005f;
+      color: white;
+      line-height: 64px;
+      font-size: 30px;
+      text-align: center;
+    }
+
+    .fancy .title {
+      position: absolute;
+      top: 30px;
+      left: 100px;
+    }
+
+    .fancy img {
+      width: 100%;
+    }
+
+    .fancy .big {
+      font-size: 22px;
+      padding: 8px 0 16px;
+      color: #888;
+    }
+
+    .fancy .medium {
+      font-size: 16px;
+      padding-bottom: 8px;
+    }
+
+  </style>
+
+</head>
+<body unresolved>
+
+  <div layout vertical center id="cards">
+
+    <paper-card>
+      <div content>
+        <div>Cards are a convenient means of displaying content composed of different types of objects.
+          <br><br>
+          <b>Swipe me!</b>
+        </div>
+      </div>
+    </paper-card>
+
+    <paper-card heading="Not all cards need to be swipeable" disableSwipe></paper-card>
+
+    <paper-card>
+      <div content>
+        <div>Lorem ipsum dolor sit amet, nec ad conceptam interpretaris, mea ne solet repudiandae. Laudem nostrud ei vim. Sapientem consequuntur usu ad, vel etiam philosophia ex, ad quidam option quo. Sed sale integre pericula ei, rebum adipiscing ius ea.
+        </div>
+      </div>
+      <div actions>
+        <core-icon-button icon="favorite" title="favorite"></core-icon-button>
+        <core-icon-button icon="bookmark" title="bookmark"></core-icon-button>
+        <core-icon-button icon="cloud-upload" title="cloud-upload"></core-icon-button>
+      </div>
+    </paper-card>
+
+    <paper-card heading="Cards can have titles" headingColor="#e9005f">
+      <div content>
+        <div>Lorem ipsum dolor sit amet, nec ad conceptam interpretaris, mea ne solet repudiandae. Laudem nostrud ei vim. Sapientem consequuntur usu ad, vel etiam philosophia ex, ad quidam option quo. Sed sale integre pericula ei, rebum adipiscing ius ea.
+        </div>
+      </div>
+      <div actions>
+        <paper-button dismissive>Nay</paper-button>
+        <paper-button affirmative autofocus>Yay!</paper-button>
+      </div>
+    </paper-card>
+
+    <paper-card heading="Titles AND images!" headingColor="#e9005f"
+                    image="http://placehold.it/350x150">
+      <div content>
+        <div>Lorem ipsum dolor sit amet, nec ad conceptam interpretaris, mea ne solet repudiandae. Laudem nostrud ei vim. Sapientem consequuntur usu ad, vel etiam philosophia ex, ad quidam option quo. Sed sale integre pericula ei, rebum adipiscing ius ea.
+        </div>
+      </div>
+      <div actions>
+        <paper-button dismissive>No</paper-button>
+        <paper-button affirmative autofocus>Yes</paper-button>
+      </div>
+    </paper-card>
+
+    <paper-card heading="Actions can be stacked" headingColor="#e9005f">
+      <div content>
+        <div>Lorem ipsum dolor sit amet, nec ad conceptam interpretaris, mea ne solet repudiandae. Laudem nostrud ei vim. Sapientem consequuntur usu ad, vel etiam philosophia ex, ad quidam option quo. Sed sale integre pericula ei, rebum adipiscing ius ea.
+        </div>
+      </div>
+      <div actions>
+        <paper-button dismissive>Action</paper-button>
+      </div>
+      <div actions>
+        <paper-button affirmative autofocus>Moar action!</paper-button>
+      </div>
+    </paper-card>
+
+    <paper-card class='fancy'>
+      <div content>
+        <div class="round-placeholder">:)</div>
+        <div class="title">
+          <div class="medium">Title</div>
+          <div class="small">subtitle</div>
+        </div>
+      </div>
+
+      <!-- take this out of the content class so that it can span the whole card -->
+      <img src="http://placehold.it/350x150">
+
+      <div content>
+        <div class="big">Usu eu novum principes, vel quodsi aliquip ea.</div>
+        <div class="medium">Ut labores minimum atomorum pro. Laudem tibique ut has.</div>
+        <div class="small">No nam ipsum lorem aliquip, accumsan quaerendum ei usu.</div>
+        <div class="small">Usu eu novum principes, vel quodsi aliquip ea.</div>
+      </div>
+    </paper-card>
+  </div>
+
+  <script>
+    document.querySelector('#cards').addEventListener('swipeable-card-swipe-away', function(e) {
+      e.target.parentNode.removeChild(e.target);
+    });
+  </script>
+
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<!--
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE
+The complete set of authors may be found at http://polymer.github.io/AUTHORS
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS
+-->
+<html>
+<head>
+
+  <script src="../webcomponentsjs/webcomponents.js"></script>
+  <link rel="import" href="../core-component-page/core-component-page.html">
+
+</head>
+<body unresolved>
+
+  <core-component-page></core-component-page>
+
+</body>
+</html>

--- a/paper-card.html
+++ b/paper-card.html
@@ -1,0 +1,149 @@
+<!--
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<!--
+Material Design: <a href="http://www.google.com/design/spec/components/card.html">Cards</a>
+
+`paper-card` is a swipeable container with a drop shadow.
+
+Example:
+
+    <paper-card heading="Card Title">
+      <div content>Some content</div>
+      <div actions>
+        <paper-button dismissive>Some action</paper-button>
+      </div actions>
+    </paper-card>
+
+Accessibility
+-------------
+
+By default, the `aria-label` will be set to the value of the `heading` attribute.
+
+@element paper-card
+@extends swipeable-card
+@homepage github.io
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+
+<link href="../swipeable-card/swipeable-card.html" rel="import">
+
+<polymer-element name="paper-card" extends="swipeable-card">
+
+<template>
+
+  <style>
+
+    :host {
+      display: inline-block;
+      position: relative;
+      background: #fff;
+      border-radius: 2px;
+      box-shadow: rgba(0, 0, 0, 0.098) 0px 2px 4px,
+                  rgba(0, 0, 0, 0.098) 0px 0px 3px;
+      transition: 300ms cubic-bezier(0.4, 0.0, 0.2, 1);
+      transition-property: opacity, -webkit-transform;
+      transition-property: opacity, transform;
+    }
+
+    :host(.dragging) {
+      transition: none;
+    }
+
+    .header {
+      position: relative;
+    }
+
+    .header img {
+      width: 100%;
+      pointer-events: none;
+    }
+
+    .header h1 {
+      font-size: 24px;
+      padding: 0 16px;
+    }
+
+    .header h1.over {
+      position: absolute;
+      bottom: 0px;
+      margin-bottom: 16px;
+    }
+
+    polyfill-next-selector { content: '> [content]' }
+    ::content > [content] {
+      padding: 16px;
+    }
+
+    polyfill-next-selector { content: '> [actions]' }
+    ::content > [actions] {
+      border-top: 1px solid #e8e8e8;
+      padding: 5px 16px;
+    }
+
+  </style>
+
+  <div class="header">
+    <template if="{{image}}">
+      <img src="{{image}}">
+    </template>
+    <template if="{{heading}}">
+      <h1 class="{{ {over: image} | tokenList }}" style="color:{{headingColor}}">{{heading}}</h1>
+    </template>
+  </div>
+
+  <content></content>
+
+</template>
+
+<script>
+
+  Polymer({
+    publish: {
+
+      /**
+       * The title of the card.
+       *
+       * @attribute heading
+       * @type string
+       * @default ''
+       */
+      heading: '',
+
+      /**
+       * The hex color of the heading.
+       *
+       * @attribute headingColor
+       * @type string
+       * @default '#000'
+       */
+      headingColor: '#000',
+
+      /**
+       * The url of the title image of the card.
+       *
+       * @attribute image
+       * @type string
+       * @default ''
+       */
+      image:''
+    },
+
+    headingChanged: function(old) {
+      var label = this.getAttribute('aria-label');
+      if (!label || label === old) {
+        this.setAttribute('aria-label', this.heading);
+      }
+    }
+
+  });
+</script>
+
+</polymer-element>

--- a/test/a11y.html
+++ b/test/a11y.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<!--
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>paper-card a11y tests</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+
+  <script src="../../webcomponentsjs/webcomponents.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+
+  <link href="../paper-card.html" rel="import">
+
+  <style>
+    paper-card {
+      width: 400px;
+    }
+  </style>
+
+</head>
+<body>
+
+  <paper-card id="card1" heading="Sample">
+    <div content><p></p></div content>
+  </paper-card>
+
+  <br>
+
+  <script>
+
+    var c1 = document.getElementById('card1');
+    test('aria-label set on card', function() {
+      assert.strictEqual(c1.getAttribute('aria-label'), c1.heading);
+    });
+
+  </script>
+
+</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<!--
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>Tests</title>
+  <script src="../../web-component-tester/browser.js"></script>
+</head>
+<body>
+  <script>
+    WCT.loadSuites([
+      'a11y.html',
+    ]);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
I extended swipeable-card and added support for most of the paper card styles from the Material Design spec. Here's one of the fancier  examples:
![paper-card-sample](https://cloud.githubusercontent.com/assets/1369170/5682186/27589a30-97ec-11e4-8bc4-4adc7d56297b.png)

@frankiefu, would you mind reviewing this, please, to make sure I didn't bork everything? Thanks!

